### PR TITLE
configure: Configure module install directory for PulseAudio.

### DIFF
--- a/modules/pa-pal-plugins/configure.ac
+++ b/modules/pa-pal-plugins/configure.ac
@@ -82,8 +82,8 @@ AM_CONDITIONAL([VUI_ENABLED], [test "x${with_VUI}" = "xyes"])
 
 AC_ARG_WITH(
         [module-dir],
-        AS_HELP_STRING([--with-module-dir],[Directory where to install the modules to (defaults to ${libdir}/pulse-${PKG_VER}/modules]),
-        [modlibexecdir=$withval], [modlibexecdir="${libdir}/pulse-${PKG_VER}/modules"])
+        AS_HELP_STRING([--with-module-dir],[Directory where to install the modules to (defaults to ${libdir}/pulseaudio/modules]),
+        [modlibexecdir=$withval], [modlibexecdir="${libdir}/pulseaudio/modules"])
 AC_SUBST(modlibexecdir)
 
 AC_CONFIG_FILES([ \


### PR DESCRIPTION
 - Updated PulseAudio modules install directory to /usr/lib/pulseaudio/modules
 - PulseAudio 17 modules now install in the pulseaudio directory.
 - PulseAudio 15 modules previously installed in pulse-15.0 directory.