### PR TITLE
pa-pal-plugins: Clean up unused sinks and sources from configuration

### DIFF
--- a/modules/pa-pal-plugins/module-pal-card/configs/qcm6490-idp-snd-card.conf
+++ b/modules/pa-pal-plugins/module-pal-card/configs/qcm6490-idp-snd-card.conf
@@ -14,18 +14,6 @@ sample-formats = s16le
 sample-rates = 48000
 channel-maps = front-left,front-right
 
-[Port headset]
-description = headset
-default-channel-map = front-left,front-right
-default-sample-rate = 48000
-direction = out
-priority = 100
-presence = always
-device = PAL_DEVICE_OUT_WIRED_HEADSET
-encodings = pcm
-sample-formats = s16le
-channel-maps = front-left,front-right
-
 [Port handset-mic]
 description = builtin mic
 default-channel-map = front-center
@@ -44,57 +32,12 @@ priority = 50
 presence = always
 device = PAL_DEVICE_IN_SPEAKER_MIC
 
-[Port headset-mic]
-description = headset input
-default-channel-map = front-left,front-right
-default-sample-rate = 48000
-direction = in
-priority = 50
-presence = always
-device = PAL_DEVICE_IN_WIRED_HEADSET
-
-[Port bta2dp-in]
-description = BT a2dp source port
-default-channel-map = front-left,front-right
-default-sample-rate = 44100
-direction = in
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_IN_BLUETOOTH_A2DP
-
-[Port bta2dp-out]
-description = BT a2dp source port
-default-channel-map = front-left,front-right
-default-sample-rate = 44100
-direction = out
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_OUT_BLUETOOTH_A2DP
-
-[Port btsco-out]
-description = BT SCO sink port
-default-channel-map = front-left
-default-sample-rate = 16000
-direction = out
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_OUT_BLUETOOTH_SCO
-
-[Port btsco-in]
-description = BT SCO source port
-default-channel-map = front-left
-default-sample-rate = 16000
-direction = in
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_IN_BLUETOOTH_SCO_HEADSET
-
 [Profile default]
 description = Default pal profile
 priority = 500
 max-sink-channels = 2
 max-source-channels = 2
-port-names = speaker speaker-mic handset-mic headset headset-mic bta2dp-out btsco-in btsco-out
+port-names = speaker speaker-mic handset-mic
 
 [Sink low-latency0]
 description = pal sink to play via low-latency path
@@ -106,50 +49,7 @@ default-channel-map = front-left,front-right
 default-buffer-size = 1024
 default-buffer-count = 4
 encodings = pcm
-port-names = speaker headset
-presence = always
-avoid-processing = rate channels
-use-hw-volume = true
-
-[Sink deep-buffer0]
-description = pal sink to play via deep buffer path
-type = PAL_STREAM_DEEP_BUFFER
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 4
-encodings = pcm
-avoid-processing = rate channels
-port-names = speaker headset bta2dp-out
-presence = always
-use-hw-volume = true
-
-[Sink offload0]
-description = pal sink to play compressed via offload path
-type = PAL_STREAM_COMPRESSED
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-encodings = mpeg aac
-default-buffer-size = 16484
-default-buffer-count = 4
-port-names = speaker headset bta2dp-out
-presence = always
-use-hw-volume = true
-
-[Sink voip-rx0]
-description = pal sink to play via voip rx path
-type = PAL_STREAM_VOIP_RX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1024
-default-buffer-count = 4
-port-names = speaker headset btsco-out
+port-names = speaker
 presence = always
 use-hw-volume = true
 
@@ -162,48 +62,6 @@ default-sample-format = s16le
 default-channel-map = front-left,front-right
 default-buffer-size = 1920
 default-buffer-count = 2
-port-names = speaker-mic handset-mic headset-mic
-avoid-processing = bitwidth rate channels
+port-names = speaker-mic handset-mic
 presence = always
 use-hw-volume = true
-
-[Source regular2]
-description = pal source to capture pcm via RAW record path
-type = PAL_STREAM_RAW
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic handset-mic headset-mic
-avoid-processing = bitwidth rate channels
-presence = always
-use-hw-volume = true
-
-[Source voip-tx0]
-description = pal source to capture pcm via voip tx record path
-type = PAL_STREAM_VOIP_TX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-center
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic handset-mic headset-mic btsco-in
-presence = always
-
-[Loopback bta2dp]
-description = pal loopback module for btsink usecase
-in-port-names = bta2dp-in
-out-port-names = speaker
-
-[Loopback hfp_tx]
-description = pal loopback module for hfp TX path
-in-port-names = speaker-mic
-out-port-names = btsco-out
-
-[Loopback hfp_rx]
-description = pal loopback module for hfp RX path
-in-port-names = btsco-in
-out-port-names = speaker

--- a/modules/pa-pal-plugins/module-pal-card/configs/qcm6490-rb3-snd-card.conf
+++ b/modules/pa-pal-plugins/module-pal-card/configs/qcm6490-rb3-snd-card.conf
@@ -19,7 +19,7 @@ description = builtin mic
 default-channel-map = front-center
 default-sample-rate = 48000
 direction = in
-priority = 50
+priority = 100
 presence = always
 device = PAL_DEVICE_IN_HANDSET_MIC
 
@@ -32,48 +32,12 @@ priority = 50
 presence = always
 device = PAL_DEVICE_IN_SPEAKER_MIC
 
-[Port bta2dp-in]
-description = BT a2dp source port
-default-channel-map = front-left,front-right
-default-sample-rate = 44100
-direction = in
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_IN_BLUETOOTH_A2DP
-
-[Port bta2dp-out]
-description = BT a2dp source port
-default-channel-map = front-left,front-right
-default-sample-rate = 44100
-direction = out
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_OUT_BLUETOOTH_A2DP
-
-[Port btsco-out]
-description = BT SCO sink port
-default-channel-map = front-left,front-right
-default-sample-rate = 16000
-direction = out
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_OUT_BLUETOOTH_SCO
-
-[Port btsco-in]
-description = BT SCO source port
-default-channel-map = front-left,front-right
-default-sample-rate = 16000
-direction = in
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_IN_BLUETOOTH_SCO_HEADSET
-
 [Profile default]
 description = Default pal profile
 priority = 500
 max-sink-channels = 2
 max-source-channels = 2
-port-names = speaker handset-mic speaker-mic bta2dp-out btsco-in btsco-out
+port-names = speaker speaker-mic handset-mic
 
 [Sink low-latency0]
 description = pal sink to play via low-latency path
@@ -84,51 +48,8 @@ default-sample-format = s16le
 default-channel-map = front-left,front-right
 default-buffer-size = 1024
 default-buffer-count = 4
+encodings = pcm
 port-names = speaker
-presence = always
-encodings = pcm
-avoid-processing = rate channels
-use-hw-volume = true
-
-[Sink deep-buffer0]
-description = pal sink to play via deep buffer path
-type = PAL_STREAM_DEEP_BUFFER
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 4
-port-names = speaker bta2dp-out
-presence = always
-encodings = pcm
-avoid-processing = rate channels
-use-hw-volume = true
-
-[Sink offload0]
-description = pal sink to play compressed via offload path
-type = PAL_STREAM_COMPRESSED
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-encodings = mpeg aac
-default-buffer-size = 16484
-default-buffer-count = 4
-port-names = speaker bta2dp-out
-presence = always
-use-hw-volume = true
-
-[Sink voip-rx0]
-description = pal sink to play via voip rx path
-type = PAL_STREAM_VOIP_RX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1024
-default-buffer-count = 4
-port-names = speaker btsco-out
 presence = always
 use-hw-volume = true
 
@@ -142,47 +63,5 @@ default-channel-map = front-left,front-right
 default-buffer-size = 1920
 default-buffer-count = 2
 port-names = speaker-mic handset-mic
-avoid-processing = bitwidth rate channels
 presence = always
 use-hw-volume = true
-
-[Source regular2]
-description = pal source to capture pcm via RAW record path
-type = PAL_STREAM_RAW
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic handset-mic
-avoid-processing = bitwidth rate channels
-presence = always
-use-hw-volume = true
-
-[Source voip-tx0]
-description = pal source to capture pcm via voip tx record path
-type = PAL_STREAM_VOIP_TX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-center
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic handset-mic btsco-in
-presence = always
-
-[Loopback bta2dp]
-description = pal loopback module for btsink usecase
-in-port-names = bta2dp-in
-out-port-names = speaker
-
-[Loopback hfp_tx]
-description = pal loopback module for hfp TX path
-in-port-names = speaker-mic
-out-port-names = btsco-out
-
-[Loopback hfp_rx]
-description = pal loopback module for hfp RX path
-in-port-names = btsco-in
-out-port-names = speaker

--- a/modules/pa-pal-plugins/module-pal-card/configs/qcm6490-rb3-vc-snd-card.conf
+++ b/modules/pa-pal-plugins/module-pal-card/configs/qcm6490-rb3-vc-snd-card.conf
@@ -19,7 +19,7 @@ description = builtin mic
 default-channel-map = front-center
 default-sample-rate = 48000
 direction = in
-priority = 50
+priority = 100
 presence = always
 device = PAL_DEVICE_IN_HANDSET_MIC
 
@@ -32,48 +32,12 @@ priority = 50
 presence = always
 device = PAL_DEVICE_IN_SPEAKER_MIC
 
-[Port bta2dp-in]
-description = BT a2dp source port
-default-channel-map = front-left,front-right
-default-sample-rate = 44100
-direction = in
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_IN_BLUETOOTH_A2DP
-
-[Port bta2dp-out]
-description = BT a2dp source port
-default-channel-map = front-left,front-right
-default-sample-rate = 44100
-direction = out
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_OUT_BLUETOOTH_A2DP
-
-[Port btsco-out]
-description = BT SCO sink port
-default-channel-map = front-left,front-right
-default-sample-rate = 16000
-direction = out
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_OUT_BLUETOOTH_SCO
-
-[Port btsco-in]
-description = BT SCO source port
-default-channel-map = front-left,front-right
-default-sample-rate = 16000
-direction = in
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_IN_BLUETOOTH_SCO_HEADSET
-
 [Profile default]
 description = Default pal profile
 priority = 500
 max-sink-channels = 2
 max-source-channels = 2
-port-names = speaker handset-mic speaker-mic bta2dp-out btsco-in btsco-out
+port-names = speaker speaker-mic handset-mic
 
 [Sink low-latency0]
 description = pal sink to play via low-latency path
@@ -84,51 +48,8 @@ default-sample-format = s16le
 default-channel-map = front-left,front-right
 default-buffer-size = 1024
 default-buffer-count = 4
+encodings = pcm
 port-names = speaker
-presence = always
-encodings = pcm
-avoid-processing = rate channels
-use-hw-volume = true
-
-[Sink deep-buffer0]
-description = pal sink to play via deep buffer path
-type = PAL_STREAM_DEEP_BUFFER
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 4
-port-names = speaker bta2dp-out
-presence = always
-encodings = pcm
-avoid-processing = rate channels
-use-hw-volume = true
-
-[Sink offload0]
-description = pal sink to play compressed via offload path
-type = PAL_STREAM_COMPRESSED
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-encodings = mpeg aac
-default-buffer-size = 16484
-default-buffer-count = 4
-port-names = speaker bta2dp-out
-presence = always
-use-hw-volume = true
-
-[Sink voip-rx0]
-description = pal sink to play via voip rx path
-type = PAL_STREAM_VOIP_RX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1024
-default-buffer-count = 4
-port-names = speaker btsco-out
 presence = always
 use-hw-volume = true
 
@@ -142,47 +63,5 @@ default-channel-map = front-left,front-right
 default-buffer-size = 1920
 default-buffer-count = 2
 port-names = speaker-mic handset-mic
-avoid-processing = bitwidth rate channels
 presence = always
 use-hw-volume = true
-
-[Source regular2]
-description = pal source to capture pcm via RAW record path
-type = PAL_STREAM_RAW
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic handset-mic
-avoid-processing = bitwidth rate channels
-presence = always
-use-hw-volume = true
-
-[Source voip-tx0]
-description = pal source to capture pcm via voip tx record path
-type = PAL_STREAM_VOIP_TX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-center
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic handset-mic btsco-in
-presence = always
-
-[Loopback bta2dp]
-description = pal loopback module for btsink usecase
-in-port-names = bta2dp-in
-out-port-names = speaker
-
-[Loopback hfp_tx]
-description = pal loopback module for hfp TX path
-in-port-names = speaker-mic
-out-port-names = btsco-out
-
-[Loopback hfp_rx]
-description = pal loopback module for hfp RX path
-in-port-names = btsco-in
-out-port-names = speaker

--- a/modules/pa-pal-plugins/module-pal-card/configs/qcm6490-rb3-vision-snd-card.conf
+++ b/modules/pa-pal-plugins/module-pal-card/configs/qcm6490-rb3-vision-snd-card.conf
@@ -19,7 +19,7 @@ description = builtin mic
 default-channel-map = front-center
 default-sample-rate = 48000
 direction = in
-priority = 50
+priority = 100
 presence = always
 device = PAL_DEVICE_IN_HANDSET_MIC
 
@@ -32,48 +32,12 @@ priority = 50
 presence = always
 device = PAL_DEVICE_IN_SPEAKER_MIC
 
-[Port bta2dp-in]
-description = BT a2dp source port
-default-channel-map = front-left,front-right
-default-sample-rate = 44100
-direction = in
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_IN_BLUETOOTH_A2DP
-
-[Port bta2dp-out]
-description = BT a2dp source port
-default-channel-map = front-left,front-right
-default-sample-rate = 44100
-direction = out
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_OUT_BLUETOOTH_A2DP
-
-[Port btsco-out]
-description = BT SCO sink port
-default-channel-map = front-left,front-right
-default-sample-rate = 16000
-direction = out
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_OUT_BLUETOOTH_SCO
-
-[Port btsco-in]
-description = BT SCO source port
-default-channel-map = front-left,front-right
-default-sample-rate = 16000
-direction = in
-priority = 50
-presence = dynamic
-device = PAL_DEVICE_IN_BLUETOOTH_SCO_HEADSET
-
 [Profile default]
 description = Default pal profile
 priority = 500
 max-sink-channels = 2
 max-source-channels = 2
-port-names = speaker handset-mic speaker-mic bta2dp-out btsco-in btsco-out
+port-names = speaker speaker-mic handset-mic
 
 [Sink low-latency0]
 description = pal sink to play via low-latency path
@@ -84,51 +48,8 @@ default-sample-format = s16le
 default-channel-map = front-left,front-right
 default-buffer-size = 1024
 default-buffer-count = 4
+encodings = pcm
 port-names = speaker
-presence = always
-encodings = pcm
-avoid-processing = rate channels
-use-hw-volume = true
-
-[Sink deep-buffer0]
-description = pal sink to play via deep buffer path
-type = PAL_STREAM_DEEP_BUFFER
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 4
-port-names = speaker bta2dp-out
-presence = always
-encodings = pcm
-avoid-processing = rate channels
-use-hw-volume = true
-
-[Sink offload0]
-description = pal sink to play compressed via offload path
-type = PAL_STREAM_COMPRESSED
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-encodings = mpeg aac
-default-buffer-size = 16484
-default-buffer-count = 4
-port-names = speaker bta2dp-out
-presence = always
-use-hw-volume = true
-
-[Sink voip-rx0]
-description = pal sink to play via voip rx path
-type = PAL_STREAM_VOIP_RX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1024
-default-buffer-count = 4
-port-names = speaker btsco-out
 presence = always
 use-hw-volume = true
 
@@ -142,47 +63,5 @@ default-channel-map = front-left,front-right
 default-buffer-size = 1920
 default-buffer-count = 2
 port-names = speaker-mic handset-mic
-avoid-processing = bitwidth rate channels
 presence = always
 use-hw-volume = true
-
-[Source regular2]
-description = pal source to capture pcm via RAW record path
-type = PAL_STREAM_RAW
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic handset-mic
-avoid-processing = bitwidth rate channels
-presence = always
-use-hw-volume = true
-
-[Source voip-tx0]
-description = pal source to capture pcm via voip tx record path
-type = PAL_STREAM_VOIP_TX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-center
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic handset-mic btsco-in
-presence = always
-
-[Loopback bta2dp]
-description = pal loopback module for btsink usecase
-in-port-names = bta2dp-in
-out-port-names = speaker
-
-[Loopback hfp_tx]
-description = pal loopback module for hfp TX path
-in-port-names = speaker-mic
-out-port-names = btsco-out
-
-[Loopback hfp_rx]
-description = pal loopback module for hfp RX path
-in-port-names = btsco-in
-out-port-names = speaker

--- a/modules/pa-pal-plugins/module-pal-card/configs/qcs8300-ridesx-snd-card.conf
+++ b/modules/pa-pal-plugins/module-pal-card/configs/qcs8300-ridesx-snd-card.conf
@@ -41,13 +41,12 @@ default-buffer-size = 1024
 default-buffer-count = 4
 encodings = pcm
 port-names = speaker
-avoid-processing = bitwidth rate channels
 presence = always
 use-hw-volume = true
 
-[Source regular2]
-description = pal source to capture pcm via RAW record path
-type = PAL_STREAM_RAW
+[Source regular0]
+description = pal source to capture pcm via deep buffer record path
+type = PAL_STREAM_DEEP_BUFFER
 default-encoding = pcm
 default-sample-rate = 48000
 default-sample-format = s16le
@@ -55,5 +54,5 @@ default-channel-map = front-left,front-right
 default-buffer-size = 1920
 default-buffer-count = 2
 port-names = speaker-mic
-avoid-processing = bitwidth rate channels
 presence = always
+use-hw-volume = true

--- a/modules/pa-pal-plugins/module-pal-card/configs/qcs9100-ridesx-snd-card.conf
+++ b/modules/pa-pal-plugins/module-pal-card/configs/qcs9100-ridesx-snd-card.conf
@@ -41,49 +41,6 @@ default-buffer-size = 1024
 default-buffer-count = 4
 encodings = pcm
 port-names = speaker
-avoid-processing = bitwidth rate channels
-presence = always
-use-hw-volume = true
-
-[Sink deep-buffer0]
-description = pal sink to play via deep buffer path
-type = PAL_STREAM_DEEP_BUFFER
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 4
-encodings = pcm
-port-names = speaker
-avoid-processing = bitwidth rate channels
-presence = always
-use-hw-volume = true
-
-[Sink offload0]
-description = pal sink to play compressed via offload path
-type = PAL_STREAM_COMPRESSED
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-encodings = mpeg
-default-buffer-size = 16484
-default-buffer-count = 4
-port-names = speaker
-presence = always
-use-hw-volume = true
-
-[Sink voip-rx0]
-description = pal sink to play via voip rx path
-type = PAL_STREAM_VOIP_RX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1024
-default-buffer-count = 4
-port-names = speaker
 presence = always
 use-hw-volume = true
 
@@ -94,34 +51,6 @@ default-encoding = pcm
 default-sample-rate = 48000
 default-sample-format = s16le
 default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic
-avoid-processing = bitwidth rate channels
-presence = always
-use-hw-volume = true
-
-[Source regular2]
-description = pal source to capture pcm via RAW record path
-type = PAL_STREAM_RAW
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-left,front-right
-default-buffer-size = 1920
-default-buffer-count = 2
-port-names = speaker-mic
-avoid-processing = bitwidth rate channels
-presence = always
-use-hw-volume = true
-
-[Source voip-tx0]
-description = pal source to capture pcm via voip tx record path
-type = PAL_STREAM_VOIP_TX
-default-encoding = pcm
-default-sample-rate = 48000
-default-sample-format = s16le
-default-channel-map = front-center
 default-buffer-size = 1920
 default-buffer-count = 2
 port-names = speaker-mic


### PR DESCRIPTION
Removed unsupported sink and source entries from machine configuration files. These nodes rely on fastrpc for dynamic module loading, which is currently not enabled