### PR TITLE
CI: Refactor pre-merge workflows and integrate LAVA trigger flow

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -1,13 +1,13 @@
 ---
 name: pre_merge_build
-run-name: Pre Merge Build (PR:${{ github.event.pull_request.number }})
+
+run-name: ${{ github.event.pull_request.number && 'Pre Merge Build PR:' || 'Pre Merge Build:' }}${{ github.event.pull_request.number || github.run_number }}
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
+    branches: [main]
     paths-ignore:
       - '.github/**'
 
@@ -25,20 +25,50 @@ jobs:
     secrets: inherit
     with:
       build_args: ${{ needs.load_parameters.outputs.build_args }}
+      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
       event_name: ${{ github.event_name }}
       pr_ref: ${{ github.event.pull_request.head.ref }}
       pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
 
   process_image:
-    needs: [ load_parameters, build ]
+    needs: [load_parameters, build]
     uses: Audioreach/audioreach-workflows/.github/workflows/process_image.yml@master
     secrets: inherit
     with:
       event_name: ${{ github.event_name }}
+      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
       pr_ref: ${{ github.event.pull_request.head.ref }}
       pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
 
-  trigger_lava:
-    needs: [ load_parameters, build, process_image ]
-    uses: Audioreach/audioreach-workflows/.github/workflows/test.yml@master
-    secrets: inherit
+  filter_test_matrix:
+    needs: load_parameters
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.filter.outputs.test_matrix }}
+    steps:
+      - id: filter
+        shell: bash
+        run: |
+          MATRIX='${{ needs.load_parameters.outputs.build_matrix }}'
+
+          echo "$MATRIX" | jq . >/dev/null
+
+          FILTERED=$(echo "$MATRIX" | jq -c '
+            if type == "object" then
+              to_entries
+              | map(select(.value.testing_enabled == true))
+              | from_entries
+            elif type == "array" then
+              map(select(.testing_enabled == true))
+            else
+              error("Unsupported JSON type")
+            end
+          ')
+
+          echo "$FILTERED" > test_matrix.json
+          echo "test_matrix=$FILTERED" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-matrix
+          path: test_matrix.json

--- a/.github/workflows/trigger_lava_on_success.yml
+++ b/.github/workflows/trigger_lava_on_success.yml
@@ -1,0 +1,95 @@
+name: trigger_lava_on_success
+
+on:
+  workflow_run:
+    workflows: ["pre_merge_build"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  prepare_matrix:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.matrix.outputs.test_matrix }}
+      build_urls: ${{ steps.read_url.outputs.build_urls }}
+
+    steps:
+      - name: Download test matrix artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test-matrix
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download presigned URL artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: presigned_url_*.txt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: presigned_urls
+          merge-multiple: true
+
+      - name: Read presigned URLs
+        id: read_url
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs')
+            const path = require('path')
+
+            const baseDir = 'presigned_urls'
+            const entries = fs.readdirSync(baseDir)
+
+            console.log('Entries:', entries)
+
+            if (entries.length === 0) {
+              throw new Error('No presigned URL files found')
+            }
+
+            const urls = {}
+
+            for (const entry of entries) {
+              const fullPath = path.join(baseDir, entry)
+              if (fs.statSync(fullPath).isFile()) {
+                const content = fs.readFileSync(fullPath, 'utf8').trim()
+                urls[entry] = content
+                console.log(`Loaded ${entry}: ${content}`)
+              }
+            }
+
+            if (Object.keys(urls).length === 0) {
+              throw new Error('No valid presigned URL files found')
+            }
+
+            core.setOutput('build_urls', JSON.stringify(urls))
+
+      - name: Re-upload presigned URL artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: presigned_urls
+          path: presigned_urls
+
+      - name: Read matrix JSON
+        id: matrix
+        shell: bash
+        run: |
+          test -f test_matrix.json
+          MATRIX=$(cat test_matrix.json)
+          echo "test_matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  trigger_lava:
+    needs: prepare_matrix
+    uses: Audioreach/audioreach-workflows/.github/workflows/test.yml@master
+    secrets: inherit
+    with:
+      build_matrix: ${{ needs.prepare_matrix.outputs.test_matrix }}
+      build_urls: ${{ needs.prepare_matrix.outputs.build_urls }}
+

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 set -ex
 echo "Running build script..."
+
+PREBUILD_SCRIPT_PATH="${PREBUILD_SCRIPT:-$(dirname "${BASH_SOURCE[0]}")/pre_build.sh}"
+source "$PREBUILD_SCRIPT_PATH"
+
+# load build args from file if environment variable is not set
+if [ -z "${BUILD_ARGS}" ]; then
+    BUILD_OPTIONS_FILE="${GITHUB_WORKSPACE}/ci/build_options.txt"
+    BUILD_ARGS="$(sed -E 's/#.*$//' "$BUILD_OPTIONS_FILE" | sed '/^[[:space:]]*$/d' | tr '\n' ' ')"
+fi
+
 # Build/Compile audioreach-pulseaudio-plugin
 source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-2a-poky-linux
 

--- a/ci/pre_build.sh
+++ b/ci/pre_build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+set -euo pipefail
+echo "Running pre-build script..."
+
+# Define target_image.json url
+url="https://raw.githubusercontent.com/AudioReach/audioreach-workflows/master/.github/actions/loading/target_image.json"
+
+# Download <sdk>.sh from aws s3 bucket and install the sdk
+if [ ! -d "${GITHUB_WORKSPACE}/install" ]; then
+    if [ -z "${SDK_NAME}" ]; then
+        echo "SDK_NAME environment variable is not set. Fetching from JSON."
+        if curl -fsSL -o target_image.json "${url}"; then
+            SDK=$(jq -r 'to_entries[0].value.SDK_name' target_image.json)
+            if [ -n "$SDK" ] && [ "$SDK" != "null" ]; then
+                export SDK_NAME="$SDK"
+                echo "SDK_NAME set to ${SDK_NAME}"
+            else
+                echo "Error: SDK_name not found in JSON." >&2
+                exit 3
+            fi
+        else
+            echo "Failed to fetch target_image.json from $url" >&2
+            exit 1
+        fi
+    fi
+    if aws s3 cp s3://qli-prd-audior-gh-artifacts/AudioReach/meta-audioreach/post_merge_build/${SDK_NAME} "${GITHUB_WORKSPACE}"; then
+        echo "SDK downloaded successfully."
+        chmod 777 "${GITHUB_WORKSPACE}/${SDK_NAME}"
+    else
+        echo "Failed to download SDK from S3. Exiting."
+        exit 1
+    fi
+    # Setup directory for sdk installation
+    mkdir -p "${GITHUB_WORKSPACE}/install"
+    orig_dir=$(pwd)
+    cd "${GITHUB_WORKSPACE}"
+    # Install the sdk
+    echo "Running SDK script..."
+    if echo "./install" | ./"${SDK_NAME}" ; then
+        echo "SDK Script ran successfully."
+    else
+        echo "Error running SDK script. Exiting."
+        exit 1
+    fi
+    cd "$orig_dir"
+else
+    echo "SDK already installed. Skipping download and installation."
+fi


### PR DESCRIPTION
Align pre-merge build workflows with audioreach-workflows [1]. Refactor CI logic to improve security, reusability, and clarity. Switch the workflow trigger from pull_request_target to pull_request to follow standard GitHub Actions practices and enhance security. Normalize YAML formatting and dependencies [2].

Refactor build and test orchestration by introducing filtering of test-ready entries from the build matrix using improved jq logic with JSON validation and support for both object and array formats. Persist the filtered results to test_matrix.json and upload it as an artifact for downstream use.

Replace inline LAVA triggering with the trigger_lava_on_success workflow. Run it after successful builds to retrieve artifacts, extract build metadata, and trigger LAVA tests using the prepared filtered matrix.

Add a reusable pre_build script to fetch the SDK from AWS S3 and move setup logic out of CI. Enable reuse in standalone and local build environments.

Grant required workflow permissions (checks and pull-requests write) to enable PR checks and allow the trigger_lava job to function correctly.

[1] AudioReach/audioreach-workflows#38
[2] AudioReach/audioreach-workflows#73